### PR TITLE
Added Undead class + Fixed smite (I think)

### DIFF
--- a/src/CortexPE/entity/mob/PigZombie.php
+++ b/src/CortexPE/entity/mob/PigZombie.php
@@ -35,10 +35,9 @@ declare(strict_types = 1);
 
 namespace CortexPE\entity\mob;
 
-use pocketmine\entity\Monster;
 use pocketmine\item\Item;
 
-class PigZombie extends Monster {
+class PigZombie extends Undead {
 
 	public const NETWORK_ID = self::ZOMBIE_PIGMAN;
 

--- a/src/CortexPE/entity/mob/Undead.php
+++ b/src/CortexPE/entity/mob/Undead.php
@@ -31,42 +31,12 @@
  *
  */
 
-declare(strict_types = 1);
-
-// Andrew Gold - Spooky Scary Skeletons
-
-/**
- * Spooky, scary skeletons
- * Send shivers down your spine
- * Shrieking skulls will shock your soul
- * Seal your doom tonight
- * Spooky, scary skeletons
- * Speak with such a screech
- * You'll shake and shudder in surprise
- * When you hear these zombies shriek
- * We're sorry skeletons, you're so misunderstood
- * You only want to socialize, but I don't think we should
- */
+declare(strict_types=1);
 
 namespace CortexPE\entity\mob;
 
-use pocketmine\item\Item;
+use pocketmine\entity\Monster;
 
-class Skeleton extends Undead {
+abstract class Undead extends Monster {
 
-	public const NETWORK_ID = self::SKELETON;
-
-	public $height = 1.99;
-	public $width = 0.6;
-
-	public function getName(): string{
-		return "Skeleton";
-	}
-
-	public function getDrops(): array{
-		return [
-			Item::get(Item::ARROW, 0, mt_rand(0, 2)),
-			Item::get(Item::BONE, 0, mt_rand(0, 2)),
-		];
-	}
 }

--- a/src/CortexPE/handlers/EnchantHandler.php
+++ b/src/CortexPE/handlers/EnchantHandler.php
@@ -35,12 +35,14 @@ declare(strict_types = 1);
 
 namespace CortexPE\handlers;
 
+use CortexPE\entity\mob\Undead;
 use CortexPE\item\enchantment\Enchantment;
 use CortexPE\Utils;
 use pocketmine\block\Block;
 use pocketmine\entity\Entity;
 use pocketmine\entity\Human;
 use pocketmine\entity\Living;
+use pocketmine\entity\Zombie;
 use pocketmine\event\block\BlockBreakEvent;
 use pocketmine\event\entity\EntityDamageByEntityEvent;
 use pocketmine\event\entity\EntityDamageEvent;
@@ -106,7 +108,7 @@ class EnchantHandler implements Listener {
 							}
 							break;
 						case Enchantment::SMITE:
-							$ev->setModifier($damage + ($lvl * 2.5), EntityDamageEvent::MODIFIER_ARMOR);
+							if($e instanceof Undead || $e instanceof Zombie) $ev->setModifier($damage + ($lvl * 2.5), EntityDamageEvent::MODIFIER_ARMOR);
 							break;
 					}
 				}


### PR DESCRIPTION
New abstract class ``CortexPE\entity\mob\Undead`` extends ``pocketmine\entity\Monster``.
``CortexPE\entity\mob\{PigZombie, Skeleton}`` Now extend the new ``Undead`` class.
Smite Enchantment now only applies to ``Undead`` mobs or ``Zombie`` extending mobs.