### PR TITLE
Fix mooshroom bug.

### DIFF
--- a/src/CortexPE/entity/mob/Mooshroom.php
+++ b/src/CortexPE/entity/mob/Mooshroom.php
@@ -58,7 +58,7 @@ class Mooshroom extends Animal {
 		if($cause instanceof EntityDamageByEntityEvent){
 			$dmg = $cause->getDamager();
 			if($dmg instanceof Player){
-				$lootingL = $dmg->getInventory()->getItemInHand()->getEnchantment(Enchantment::LOOTING)->getLevel();
+				$lootingL = $dmg->getInventory()->getItemInHand()->getEnchantmentLevel(Enchantment::LOOTING);
 			}
 		}
 


### PR DESCRIPTION
Not sure why, how, and how long this bug has been there for, but this needed fixing.
This bug only occurred if the mob attempted to die when a player were to kill them, it would then kick them for an internal server error.
This could’ve been a change that pocketmine introduced, or simply it was a typo to how it should’ve been dealt with. getEnchantmentLevel() is better than getLevel() and works like a charm.
You may want to test this out to see if it’s fixed, but on my end, it’s completely fixed. No errors, no nothing.
Please merge this PR when ready.
Thank you!