### PR TITLE
Update for Compatibility with PocketMine-MP 3.9.0

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -1,7 +1,7 @@
 name: TeaSpoon
 main: CortexPE\Main
-version: 1.1.2
-api: 3.5.1
+version: 1.2.0
+api: 3.9.0
 load: STARTUP
 author: CortexPE
 description: A PLUGIN to Extend PMMP's Functionality without completely changing it.

--- a/src/CortexPE/Session.php
+++ b/src/CortexPE/Session.php
@@ -38,7 +38,7 @@ namespace CortexPE;
 use CortexPE\entity\projectile\FishingHook;
 use CortexPE\item\Elytra;
 use pocketmine\entity\Vehicle;
-use pocketmine\network\mcpe\protocol\EntityEventPacket;
+use pocketmine\network\mcpe\protocol\ActorEventPacket;
 use pocketmine\Player;
 use pocketmine\Server as PMServer;
 
@@ -72,7 +72,7 @@ class Session {
 		$this->fishing = false;
 
 		if($this->fishingHook instanceof FishingHook){
-			$this->fishingHook->broadcastEntityEvent(EntityEventPacket::FISH_HOOK_TEASE, null, $this->fishingHook->getViewers());
+			$this->fishingHook->broadcastEntityEvent(ActorEventPacket::FISH_HOOK_TEASE, null, $this->fishingHook->getViewers());
 
 			if(!$this->fishingHook->isFlaggedForDespawn()){
 				$this->fishingHook->flagForDespawn();

--- a/src/CortexPE/entity/projectile/FireworkRocket.php
+++ b/src/CortexPE/entity/projectile/FireworkRocket.php
@@ -22,9 +22,9 @@ use pocketmine\item\Item;
 use pocketmine\level\Level;
 use pocketmine\nbt\tag\ByteTag;
 use pocketmine\nbt\tag\CompoundTag;
-use pocketmine\network\mcpe\protocol\EntityEventPacket;
+use pocketmine\network\mcpe\protocol\ActorEventPacket;
 use pocketmine\network\mcpe\protocol\LevelSoundEventPacket;
-use pocketmine\network\mcpe\protocol\SetEntityDataPacket;
+use pocketmine\network\mcpe\protocol\SetActorDataPacket;
 use pocketmine\Player;
 use pocketmine\utils\Random;
 
@@ -54,7 +54,7 @@ class FireworkRocket extends Projectile {
 		if(!is_array($player)){
 			$player = [$player];
 		}
-		$pk = new SetEntityDataPacket();
+		$pk = new SetActorDataPacket();
 		$pk->entityRuntimeId = $this->getId();
 		$pk->metadata = $data ?? $this->getDataPropertyManager()->getDirty();
 		foreach($player as $p){
@@ -93,7 +93,7 @@ class FireworkRocket extends Projectile {
 			}
 		}
 
-		$this->broadcastEntityEvent(EntityEventPacket::FIREWORK_PARTICLES, 0);
+		$this->broadcastEntityEvent(ActorEventPacket::FIREWORK_PARTICLES, 0);
 		parent::despawnFromAll();
 		$this->level->broadcastLevelSoundEvent($this, LevelSoundEventPacket::SOUND_BLAST);
 	}

--- a/src/CortexPE/entity/projectile/FishingHook.php
+++ b/src/CortexPE/entity/projectile/FishingHook.php
@@ -45,7 +45,7 @@ use pocketmine\event\entity\EntityDamageByEntityEvent;
 use pocketmine\event\entity\EntityDamageEvent;
 use pocketmine\event\entity\ProjectileHitEntityEvent;
 use pocketmine\math\RayTraceResult;
-use pocketmine\network\mcpe\protocol\EntityEventPacket;
+use pocketmine\network\mcpe\protocol\ActorEventPacket;
 use pocketmine\Player;
 use pocketmine\Server as PMServer;
 
@@ -88,9 +88,9 @@ class FishingHook extends Projectile {
 				if($block instanceof Water || $block instanceof StillWater){
 					$this->touchedWater = true;
 
-					$pk = new EntityEventPacket();
+					$pk = new ActorEventPacket();
 					$pk->entityRuntimeId = $this->getId();
-					$pk->event = EntityEventPacket::FISH_HOOK_POSITION;
+					$pk->event = ActorEventPacket::FISH_HOOK_POSITION;
 					PMServer::getInstance()->broadcastPacket($this->getViewers(), $pk);
 
 					break;
@@ -122,9 +122,9 @@ class FishingHook extends Projectile {
 	public function attractFish(){
 		$oe = $this->getOwningEntity();
 		if($oe instanceof Player){
-			$pk = new EntityEventPacket();
+			$pk = new ActorEventPacket();
 			$pk->entityRuntimeId = $this->getId();
-			$pk->event = EntityEventPacket::FISH_HOOK_BUBBLE;
+			$pk->event = ActorEventPacket::FISH_HOOK_BUBBLE;
 			PMServer::getInstance()->broadcastPacket($this->getViewers(), $pk);
 		}
 	}
@@ -132,9 +132,9 @@ class FishingHook extends Projectile {
 	public function fishBites(){
 		$oe = $this->getOwningEntity();
 		if($oe instanceof Player){
-			$pk = new EntityEventPacket();
+			$pk = new ActorEventPacket();
 			$pk->entityRuntimeId = $this->getId();
-			$pk->event = EntityEventPacket::FISH_HOOK_HOOK;
+			$pk->event = ActorEventPacket::FISH_HOOK_HOOK;
 			PMServer::getInstance()->broadcastPacket($this->getViewers(), $pk);
 		}
 	}

--- a/src/CortexPE/entity/projectile/ThrownTrident.php
+++ b/src/CortexPE/entity/projectile/ThrownTrident.php
@@ -42,7 +42,7 @@ use pocketmine\entity\projectile\Projectile;
 use pocketmine\item\Item;
 use pocketmine\math\RayTraceResult;
 use pocketmine\network\mcpe\protocol\PlaySoundPacket;
-use pocketmine\network\mcpe\protocol\TakeItemEntityPacket;
+use pocketmine\network\mcpe\protocol\TakeItemActorPacket;
 use pocketmine\Player;
 use pocketmine\Server;
 
@@ -84,7 +84,7 @@ class ThrownTrident extends Projectile {
 			return;
 		}
 
-		$pk = new TakeItemEntityPacket();
+		$pk = new TakeItemActorPacket();
 		$pk->eid = $player->getId();
 		$pk->target = $this->getId();
 		$this->server->broadcastPacket($this->getViewers(), $pk);

--- a/src/CortexPE/entity/vehicle/Boat.php
+++ b/src/CortexPE/entity/vehicle/Boat.php
@@ -27,7 +27,7 @@ use pocketmine\item\Item as ItemItem;
 use pocketmine\nbt\tag\{
 	ByteTag
 };
-use pocketmine\network\mcpe\protocol\EntityEventPacket;
+use pocketmine\network\mcpe\protocol\ActorEventPacket;
 use pocketmine\Server as PMServer;
 
 class Boat extends Vehicle {
@@ -67,7 +67,7 @@ class Boat extends Vehicle {
 	public function attack(EntityDamageEvent $source): void{
 		parent::attack($source);
 		if(!$source->isCancelled()){
-			$pk = new EntityEventPacket();
+			$pk = new ActorEventPacket();
 			$pk->entityRuntimeId = $this->id;
 			$pk->event = EntityEventPacket::HURT_ANIMATION;
 			PMServer::getInstance()->broadcastPacket($this->getViewers(), $pk);

--- a/src/CortexPE/entity/vehicle/Vehicle.php
+++ b/src/CortexPE/entity/vehicle/Vehicle.php
@@ -41,7 +41,7 @@ use pocketmine\event\entity\EntityDamageEvent;
 use pocketmine\level\Level;
 use pocketmine\math\Vector3;
 use pocketmine\nbt\tag\CompoundTag;
-use pocketmine\network\mcpe\protocol\SetEntityLinkPacket;
+use pocketmine\network\mcpe\protocol\SetActorLinkPacket;
 use pocketmine\network\mcpe\protocol\types\EntityLink;
 use pocketmine\Player;
 
@@ -153,7 +153,7 @@ abstract class Vehicle extends PMVehicle {
 		if(isset($entity->riding) && !is_null($entity->riding)){
 			// TODO: an event for the interaction
 
-			$pk = new SetEntityLinkPacket();
+			$pk = new SetActorLinkPacket();
 			$riding->fromEntityUniqueId = $this->getId(); //Weird Weird Weird
 			$riding->toEntityUniqueId = $entity->getId();
 			$riding->type = EntityLink::TYPE_REMOVE;
@@ -162,7 +162,7 @@ abstract class Vehicle extends PMVehicle {
 
 			// Second packet, need to be send to player
 			if($entity instanceof Player){
-				$pk = new SetEntityLinkPacket();
+				$pk = new SetActorLinkPacket();
 				$riding->fromEntityUniqueId = $this->getId(); //Weird Weird Weird
 				$riding->toEntityUniqueId = $entity->getId();
 				$riding->type = EntityLink::TYPE_REMOVE;
@@ -177,7 +177,7 @@ abstract class Vehicle extends PMVehicle {
 			return true;
 		}
 
-		$pk = new SetEntityLinkPacket();
+		$pk = new SetActorLinkPacket();
 		$riding->fromEntityUniqueId = $this->getId();
 		$riding->toEntityUniqueId = $entity->getId();
 		$riding->type = EntityLink::TYPE_PASSENGER;
@@ -186,7 +186,7 @@ abstract class Vehicle extends PMVehicle {
 
 		// Send the other packet to the player
 		if($entity instanceof Player){
-			$pk = new SetEntityLinkPacket();
+			$pk = new SetActorLinkPacket();
 			$riding->fromEntityUniqueId = $this->getId();
 			$riding->toEntityUniqueId = 0;
 			$riding->type = EntityLink::TYPE_PASSENGER;

--- a/src/CortexPE/utils/EntityUtils.php
+++ b/src/CortexPE/utils/EntityUtils.php
@@ -42,7 +42,7 @@ use CortexPE\Utils;
 use pocketmine\block\Block;
 use pocketmine\entity\Entity;
 use pocketmine\math\Vector3;
-use pocketmine\network\mcpe\protocol\SetEntityLinkPacket;
+use pocketmine\network\mcpe\protocol\SetActorLinkPacket;
 use pocketmine\network\mcpe\protocol\types\EntityLink;
 use pocketmine\Player;
 use pocketmine\Server;
@@ -111,7 +111,7 @@ class EntityUtils extends Utils {
 				$entity->setDataFlag(Entity::DATA_FLAGS, Entity::DATA_FLAG_RIDING, true);
 				$entity->setDataFlag(Entity::DATA_FLAGS, Entity::DATA_FLAG_WASD_CONTROLLED, true);
 
-				$pk = new SetEntityLinkPacket();
+				$pk = new SetActorLinkPacket();
 				$pk->link = new EntityLink($entity->getId(), $vehicle->getId(), $type);
 				Server::getInstance()->broadcastPacket($entity->getViewers(), $pk);
 				if($entity instanceof Player){
@@ -147,7 +147,7 @@ class EntityUtils extends Utils {
 					$dpm->removeProperty(Entity::DATA_RIDER_MIN_ROTATION);
 				}
 
-				$pk = new SetEntityLinkPacket();
+				$pk = new SetActorLinkPacket();
 				$pk->link = new EntityLink($entity->getId(), $vehicle->getId(), EntityLink::TYPE_REMOVE);
 				Server::getInstance()->broadcastPacket($entity->getViewers(), $pk);
 				if($entity instanceof Player){


### PR DESCRIPTION
Update Packets to use Actor packets instead of Entity Packets where necessary for PocketMine-MP 3.9.0